### PR TITLE
Set the `not found` text instead of appending it

### DIFF
--- a/javascript/hash.js
+++ b/javascript/hash.js
@@ -93,7 +93,7 @@ function potentiallyContains() {
 	for (var n = 0; n < numHashFunctions; n++) {
 		var hashNum = nthHash(n, str);
 		if (!(m_bits[hashNum])) {
-			document.getElementById('found').innerHTML += "not found";
+			document.getElementById('found').innerHTML = "not found";
 			return false;
 		}
 		bitList.push(hashNum);


### PR DESCRIPTION
Multiple presses of the `check` button duplicates the `not found` message when matches are not found:

<img width="429" alt="screen shot 2017-07-04 at 3 20 53 pm" src="https://user-images.githubusercontent.com/1587282/27841090-796a487c-60cc-11e7-8715-feac0a5c48f2.png">

This should fix it :)